### PR TITLE
ubuntu24.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
-# pull the c-bindings
-FROM rust AS bindings
-RUN cargo install cargo-c
-
-
 # build the gstreamer ndi plugin
-FROM rust AS builder
-COPY --from=bindings /usr/local/cargo/bin /usr/local/cargo/bin
+FROM ubuntu:24.10 AS builder
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 
 RUN apt-get update && apt-get -y install \
+    rustc \
+    cargo \
+    curl \
     build-essential \
     libgstreamer1.0-dev \
     libgstreamer-plugins-base1.0-dev
 
-# GST_PLUGINS_COMMIT=main to use the latest commit
+# ENV GST_PLUGINS_COMMIT=main to use the latest commit
 ENV GST_PLUGINS_COMMIT=d5425c52251f3fc0c21a6d994f9e1e6b46670daf
 
 RUN cd /opt && \
@@ -22,12 +19,12 @@ RUN cd /opt && \
     mkdir gst-plugins-rs-dev && \
     tar -xjvf gst-plugins-rs-$GST_PLUGINS_COMMIT.tar.bz2 --strip-components=1 -C gst-plugins-rs-dev/ gst-plugins-rs-$GST_PLUGINS_COMMIT && \
     cd gst-plugins-rs-dev && \
-    cargo cbuild -p gst-plugin-ndi --release
+    cargo build -p gst-plugin-ndi --release
 
 
 # run
-FROM ubuntu:24.04 AS runner
-COPY --from=builder /opt/gst-plugins-rs-dev/target /opt/gst-plugins-rs/target
+FROM ubuntu:24.10 AS runner
+COPY --from=builder /opt/gst-plugins-rs-dev/target/release/*.so /opt/gst-plugins-rs/
 
 WORKDIR /app
 COPY . /app
@@ -35,14 +32,12 @@ COPY . /app
 ARG DEBIAN_FRONTEND="noninteractive"
 SHELL ["/bin/bash", "-c"]
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
+ENV GST_PLUGIN_PATH="/opt/gst-plugins-rs"
 
 RUN apt-get update && apt-get -y install \
-   pkg-config \
    sudo \
    curl \
    avahi-daemon \
-   libgstreamer1.0-dev \
-   libgstreamer-plugins-base1.0-dev \
    gstreamer1.0-plugins-base \
    gstreamer1.0-plugins-good \
    gstreamer1.0-plugins-bad \
@@ -51,12 +46,10 @@ RUN apt-get update && apt-get -y install \
    gstreamer1.0-plugins-base-apps \
    gstreamer1.0-libav
 
-RUN sudo install -m 755 /opt/gst-plugins-rs/target/*/release/*.so $(pkg-config --variable=pluginsdir gstreamer-1.0)/
-
 # LibNDI
 # alternatively, get the release .deb from https://github.com/DistroAV/DistroAV/releases
-RUN curl -O --output-dir /tmp https://raw.githubusercontent.com/DistroAV/DistroAV/6.0.0/CI/libndi-get.sh && \
-   bash /tmp/libndi-get.sh install
+RUN curl -O --output-dir /tmp https://raw.githubusercontent.com/DistroAV/DistroAV/6.0.0/CI/libndi-get.sh
+RUN bash /tmp/libndi-get.sh install
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN chmod +x /app/container-startup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN apt-get update && apt-get -y install \
 
 # LibNDI
 # alternatively, get the release .deb from https://github.com/DistroAV/DistroAV/releases
-RUN curl -O --output-dir /tmp https://raw.githubusercontent.com/DistroAV/DistroAV/6.0.0/CI/libndi-get.sh
-RUN bash /tmp/libndi-get.sh install
+RUN curl -O --output-dir /tmp https://raw.githubusercontent.com/DistroAV/DistroAV/6.0.0/CI/libndi-get.sh && \
+   bash /tmp/libndi-get.sh install
 
 RUN rm -rf /var/lib/apt/lists/*
 RUN chmod +x /app/container-startup.sh


### PR DESCRIPTION
- run and build on ubuntu 24.10, which has gstreamer `1.24.8` (current is `1.24.9` atm)
- it now runs and builds against the same gstreamer version
- cargo-c is actually not needed to build the plugin
- streamline plugin installation
- removed unnecessary packages

tested, works fine

the container might be bigger again on docker hub, but that doesn't matter imo..